### PR TITLE
poc: avoid travis 'maximum time limit for jobs' error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,15 +50,20 @@ jobs:
         - BONITA_BUILD_STUDIO_SKIP=true
       before_cache:
         # Maven: ensure that we do not keep bonitasoft artifacts across builds
-        - rm -rf $HOME/.m2/repository/org/bonitasoft
+        # temp bonita dependencies must be available for studio
+        #TODO store them in the cache but remove them prior building (in the before_script phase)
+        #- rm -rf $HOME/.m2/repository/org/bonitasoft
         # Gradle: see https://docs.travis-ci.com/user/languages/java/#projects-using-gradle
         - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
         - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+      before_script:
+        - ls -lh $HOME/.m2
+        - cat $HOME/.m2/settings.xml
       script: ./build-script.sh
     - stage: build studio
       env:
-        - BONITA_BUILD_STUDIO_ONLY=true
         - BONITA_BUILD_QUIET=false
+        - BONITA_BUILD_STUDIO_ONLY=true
       install:
         # openjdk11 should be installed
         # https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,9 @@ jobs:
         - /usr/local/lib/jvm/openjdk11/bin/java --version
         - export BONITA_BUILD_QUIET=false
         - export BONITA_BUILD_STUDIO_ONLY=true
+        before_cache:
+        # remove studio-only configuration
+        - rm -f  $HOME/.m2/toolchains.xml
       before_script:
         # copy maven toolchains.xml configuration file
         - ls -lh $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ branches:
 env:
   global:
     - BONITA_BUILD_NO_CLEAN=true
-    - BONITA_BUILD_QUIET=true
 
 install:
   # openjdk11 should be installed
@@ -47,6 +46,7 @@ jobs:
   include:
     - stage: build without studio
       env:
+        - BONITA_BUILD_QUIET=true
         - BONITA_BUILD_STUDIO_SKIP=true
 #      script: ./build-script.sh
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
+
 branches:
   only:
   - master
@@ -50,7 +51,10 @@ jobs:
 #      script: ./build-script.sh
       script:
         - echo "simulate build without studio"
+        - ls -lh $HOME/.m2
+        - ls -lh $HOME/.m2/repository
         - ls -lh $HOME/.m2/repository/org
+        - set
     - stage: build studio
       env:
         - BONITA_BUILD_STUDIO_ONLY=true
@@ -58,4 +62,7 @@ jobs:
 #      script: ./build-script.sh
       script:
         - echo "simulate build without studio"
+        - ls -lh $HOME/.m2
+        - ls -lh $HOME/.m2/repository
         - ls -lh $HOME/.m2/repository/org
+        - set

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,10 @@ jobs:
         - export BONITA_BUILD_STUDIO_SKIP=true
       script: ./build-script.sh
     - stage: build studio
-    # see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services
-    services:
-      - xvfb
-    install:
+      # see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services
+      services:
+        - xvfb
+      install:
         # openjdk11 should be installed
         # https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support
         - /usr/local/lib/jvm/openjdk11/bin/java --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ jdk: openjdk8
 os: linux
 dist: xenial
 
-## for studio build
-## see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services
-#services:
-#  - xvfb
+# for studio build
+# see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services
+services:
+  - xvfb
 
 #before_cache:
 #  # Maven: ensure that we do not keep bonitasoft artifacts across builds
@@ -56,9 +56,6 @@ jobs:
         - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
       script: ./build-script.sh
     - stage: build studio
-      # see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services
-      services:
-        - xvfb
       env:
         - BONITA_BUILD_STUDIO_ONLY=true
         - BONITA_BUILD_QUIET=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,6 @@ before_script:
   - ls -lh $HOME/.m2
   - cp  .travis/maven/toolchains.xml $HOME/.m2/
   - ls -lh $HOME/.m2
-# see https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
+# for 'travis_wait', see https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
+# needed because the Studio build lasts more than 10 minutes and do not log anything when quiet mode is used
 script: ./build-script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,5 @@ before_script:
   - ls -lh $HOME/.m2
 # for 'travis_wait', see https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
 # needed because the Studio build lasts more than 10 minutes and do not log anything when quiet mode is used
+# about build timeouts, see https://docs.travis-ci.com/user/customizing-the-build/#build-timeouts
 script: ./build-script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,9 @@ env:
 jobs:
   include:
     - stage: build without studio
-      env:
-        - BONITA_BUILD_QUIET=true
-        - BONITA_BUILD_STUDIO_SKIP=true
+#      env:
+#        - BONITA_BUILD_QUIET=true
+#        - BONITA_BUILD_STUDIO_SKIP=true
       before_cache:
         # Maven: ensure that we do not keep bonitasoft artifacts across builds
         # temp bonita dependencies must be available for studio
@@ -58,16 +58,21 @@ jobs:
         - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
       before_script:
         - ls -lh $HOME/.m2
-        - cat $HOME/.m2/settings.xml
+        # do not declare environment variables in the env section to ensure the cache is shared by jobs
+        # see https://docs.travis-ci.com/user/caching/#caches-and-build-matrices
+        - export BONITA_BUILD_QUIET=true
+        - export BONITA_BUILD_STUDIO_SKIP=true
       script: ./build-script.sh
     - stage: build studio
-      env:
-        - BONITA_BUILD_QUIET=false
-        - BONITA_BUILD_STUDIO_ONLY=true
+#      env:
+#        - BONITA_BUILD_QUIET=false
+#        - BONITA_BUILD_STUDIO_ONLY=true
       install:
         # openjdk11 should be installed
         # https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support
         - /usr/local/lib/jvm/openjdk11/bin/java --version
+        - export BONITA_BUILD_QUIET=false
+        - export BONITA_BUILD_STUDIO_ONLY=true
       before_script:
         # copy maven toolchains.xml configuration file
         - ls -lh $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
         - /usr/local/lib/jvm/openjdk11/bin/java --version
         - export BONITA_BUILD_QUIET=false
         - export BONITA_BUILD_STUDIO_ONLY=true
-        before_cache:
+      before_cache:
         # remove studio-only configuration
         - rm -f  $HOME/.m2/toolchains.xml
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,6 @@ jobs:
         # remove studio-only configuration
         - rm -f  $HOME/.m2/toolchains.xml
       before_script:
-        # copy maven toolchains.xml configuration file
-        - ls -lh $HOME/.m2
-        - cp  .travis/maven/toolchains.xml $HOME/.m2/
-        - ls -lh $HOME/.m2
+        # studio-only configuration
+        - cp .travis/maven/toolchains.xml $HOME/.m2/
       script: ./build-script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
   global:
     - SCRIPT_BUILD_NO_CLEAN=true
     - SCRIPT_BUILD_QUIET=true
+    - BONITA_BUILD_STUDIO_SKIP=true
 
 install:
   # openjdk11 should be installed

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,13 @@ jobs:
   include:
     - stage: build without studio
       before_cache:
-        # Maven: ensure that we do not keep bonitasoft artifacts across builds
-        # temp bonita dependencies must be available for studio
-        #TODO store them in the cache but remove them prior building (in the before_script phase)
-        #- rm -rf $HOME/.m2/repository/org/bonitasoft
         # Gradle: see https://docs.travis-ci.com/user/languages/java/#projects-using-gradle
         - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
         - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
       before_script:
-        - ls -lh $HOME/.m2
+        # Maven: ensure that we do not keep bonitasoft artifacts across builds
+        # They are not removed from the cache (via before_cache) as they are required by the Studio job
+        - rm -rf $HOME/.m2/repository/org/bonitasoft
         # do not declare environment variables in the env section to ensure the cache is shared by jobs
         # see https://docs.travis-ci.com/user/caching/#caches-and-build-matrices
         - export BONITA_BUILD_QUIET=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
   global:
     - SCRIPT_BUILD_NO_CLEAN=true
     - SCRIPT_BUILD_QUIET=true
-    - BONITA_BUILD_STUDIO_SKIP=true
 
 install:
   # openjdk11 should be installed
@@ -42,4 +41,21 @@ before_script:
   - ls -lh $HOME/.m2
   - cp  .travis/maven/toolchains.xml $HOME/.m2/
   - ls -lh $HOME/.m2
-script: ./build-script.sh
+
+jobs:
+  include:
+    - stage: build without studio
+      env:
+        - BONITA_BUILD_STUDIO_SKIP=true
+#      script: ./build-script.sh
+      script:
+        - echo "simulate build without studio"
+        - ls -lh $HOME/.m2/repository/org
+    - stage: build studio
+      env:
+        - BONITA_BUILD_STUDIO_ONLY=true
+        - SCRIPT_BUILD_QUIET=false
+#      script: ./build-script.sh
+      script:
+        - echo "simulate build without studio"
+        - ls -lh $HOME/.m2/repository/org

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ jdk: openjdk8
 os: linux
 dist: xenial
 
-# for studio build
-# see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services
-services:
-  - xvfb
+## for studio build
+## see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services
+#services:
+#  - xvfb
 
 before_cache:
   # Maven: ensure that we do not keep bonitasoft artifacts across builds
@@ -32,15 +32,15 @@ env:
   global:
     - BONITA_BUILD_NO_CLEAN=true
 
-install:
-  # openjdk11 should be installed
-  # https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support
-  - /usr/local/lib/jvm/openjdk11/bin/java --version
-before_script:
-  # copy maven toolchains.xml configuration file
-  - ls -lh $HOME/.m2
-  - cp  .travis/maven/toolchains.xml $HOME/.m2/
-  - ls -lh $HOME/.m2
+#install:
+#  # openjdk11 should be installed
+#  # https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support
+#  - /usr/local/lib/jvm/openjdk11/bin/java --version
+#before_script:
+#  # copy maven toolchains.xml configuration file
+#  - ls -lh $HOME/.m2
+#  - cp  .travis/maven/toolchains.xml $HOME/.m2/
+#  - ls -lh $HOME/.m2
 
 jobs:
   include:
@@ -52,12 +52,24 @@ jobs:
       script:
         - echo "simulate build without studio"
         - ls -lh $HOME/.m2
-        - ls -lh $HOME/.m2/repository
-        - ls -lh $HOME/.m2/repository/org
+#        - ls -lh $HOME/.m2/repository
+#        - ls -lh $HOME/.m2/repository/org
     - stage: build studio
+      # see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services
+      services:
+        - xvfb
       env:
         - BONITA_BUILD_STUDIO_ONLY=true
         - BONITA_BUILD_QUIET=false
+      install:
+        # openjdk11 should be installed
+        # https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support
+        - /usr/local/lib/jvm/openjdk11/bin/java --version
+      before_script:
+        # copy maven toolchains.xml configuration file
+        - ls -lh $HOME/.m2
+        - cp  .travis/maven/toolchains.xml $HOME/.m2/
+        - ls -lh $HOME/.m2
 #      script: ./build-script.sh
       script:
         - echo "simulate build without studio"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ jdk: openjdk8
 os: linux
 dist: xenial
 
-# for studio build
-# see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services
-services:
-  - xvfb
-
 cache:
   directories:
     # Maven dependencies and wrappers
@@ -46,7 +41,10 @@ jobs:
         - export BONITA_BUILD_STUDIO_SKIP=true
       script: ./build-script.sh
     - stage: build studio
-      install:
+    # see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services
+    services:
+      - xvfb
+    install:
         # openjdk11 should be installed
         # https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support
         - /usr/local/lib/jvm/openjdk11/bin/java --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ before_script:
   - cp  .travis/maven/toolchains.xml $HOME/.m2/
   - ls -lh $HOME/.m2
 # see https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
-script: travis_wait 75 ./build-script.sh
+script: ./build-script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ dist: xenial
 #services:
 #  - xvfb
 
-before_cache:
-  # Maven: ensure that we do not keep bonitasoft artifacts across builds
-  - rm -rf $HOME/.m2/repository/org/bonitasoft
-  # Gradle: see https://docs.travis-ci.com/user/languages/java/#projects-using-gradle
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+#before_cache:
+#  # Maven: ensure that we do not keep bonitasoft artifacts across builds
+#  - rm -rf $HOME/.m2/repository/org/bonitasoft
+#  # Gradle: see https://docs.travis-ci.com/user/languages/java/#projects-using-gradle
+#  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+#  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
     # Maven dependencies and wrappers
@@ -48,12 +48,13 @@ jobs:
       env:
         - BONITA_BUILD_QUIET=true
         - BONITA_BUILD_STUDIO_SKIP=true
-#      script: ./build-script.sh
-      script:
-        - echo "simulate build without studio"
-        - ls -lh $HOME/.m2
-#        - ls -lh $HOME/.m2/repository
-#        - ls -lh $HOME/.m2/repository/org
+      before_cache:
+        # Maven: ensure that we do not keep bonitasoft artifacts across builds
+        - rm -rf $HOME/.m2/repository/org/bonitasoft
+        # Gradle: see https://docs.travis-ci.com/user/languages/java/#projects-using-gradle
+        - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+        - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+      script: ./build-script.sh
     - stage: build studio
       # see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services
       services:
@@ -70,9 +71,4 @@ jobs:
         - ls -lh $HOME/.m2
         - cp  .travis/maven/toolchains.xml $HOME/.m2/
         - ls -lh $HOME/.m2
-#      script: ./build-script.sh
-      script:
-        - echo "simulate build without studio"
-        - ls -lh $HOME/.m2
-        - ls -lh $HOME/.m2/repository
-        - ls -lh $HOME/.m2/repository/org
+      script: ./build-script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ jobs:
         - ls -lh $HOME/.m2
         - ls -lh $HOME/.m2/repository
         - ls -lh $HOME/.m2/repository/org
-        - set
     - stage: build studio
       env:
         - BONITA_BUILD_STUDIO_ONLY=true
@@ -65,4 +64,3 @@ jobs:
         - ls -lh $HOME/.m2
         - ls -lh $HOME/.m2/repository
         - ls -lh $HOME/.m2/repository/org
-        - set

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,4 @@ before_script:
   - ls -lh $HOME/.m2
   - cp  .travis/maven/toolchains.xml $HOME/.m2/
   - ls -lh $HOME/.m2
-# for 'travis_wait', see https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
-# needed because the Studio build lasts more than 10 minutes and do not log anything when quiet mode is used
-# about build timeouts, see https://docs.travis-ci.com/user/customizing-the-build/#build-timeouts
 script: ./build-script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,6 @@ dist: xenial
 services:
   - xvfb
 
-#before_cache:
-#  # Maven: ensure that we do not keep bonitasoft artifacts across builds
-#  - rm -rf $HOME/.m2/repository/org/bonitasoft
-#  # Gradle: see https://docs.travis-ci.com/user/languages/java/#projects-using-gradle
-#  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-#  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
     # Maven dependencies and wrappers
@@ -32,22 +26,10 @@ env:
   global:
     - BONITA_BUILD_NO_CLEAN=true
 
-#install:
-#  # openjdk11 should be installed
-#  # https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support
-#  - /usr/local/lib/jvm/openjdk11/bin/java --version
-#before_script:
-#  # copy maven toolchains.xml configuration file
-#  - ls -lh $HOME/.m2
-#  - cp  .travis/maven/toolchains.xml $HOME/.m2/
-#  - ls -lh $HOME/.m2
 
 jobs:
   include:
     - stage: build without studio
-#      env:
-#        - BONITA_BUILD_QUIET=true
-#        - BONITA_BUILD_STUDIO_SKIP=true
       before_cache:
         # Maven: ensure that we do not keep bonitasoft artifacts across builds
         # temp bonita dependencies must be available for studio
@@ -64,9 +46,6 @@ jobs:
         - export BONITA_BUILD_STUDIO_SKIP=true
       script: ./build-script.sh
     - stage: build studio
-#      env:
-#        - BONITA_BUILD_QUIET=false
-#        - BONITA_BUILD_STUDIO_ONLY=true
       install:
         # openjdk11 should be installed
         # https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ branches:
 
 env:
   global:
-    - SCRIPT_BUILD_NO_CLEAN=true
-    - SCRIPT_BUILD_QUIET=true
+    - BONITA_BUILD_NO_CLEAN=true
+    - BONITA_BUILD_QUIET=true
 
 install:
   # openjdk11 should be installed
@@ -57,7 +57,7 @@ jobs:
     - stage: build studio
       env:
         - BONITA_BUILD_STUDIO_ONLY=true
-        - SCRIPT_BUILD_QUIET=false
+        - BONITA_BUILD_QUIET=false
 #      script: ./build-script.sh
       script:
         - echo "simulate build without studio"

--- a/build-script.sh
+++ b/build-script.sh
@@ -18,8 +18,8 @@ export OPENSSL_CONF=/etc/ssl
 
 # Script configuration
 # You can set the following environment variables
-SCRIPT_BUILD_NO_CLEAN=${SCRIPT_BUILD_NO_CLEAN:-false}
-SCRIPT_BUILD_QUIET=${SCRIPT_BUILD_QUIET:-false}
+BONITA_BUILD_NO_CLEAN=${BONITA_BUILD_NO_CLEAN:-false}
+BONITA_BUILD_QUIET=${BONITA_BUILD_QUIET:-false}
 BONITA_BUILD_STUDIO_ONLY=${BONITA_BUILD_STUDIO_ONLY:-false}
 BONITA_BUILD_STUDIO_SKIP=${BONITA_BUILD_STUDIO_SKIP:-false}
 
@@ -117,7 +117,7 @@ build_gradle_wrapper() {
 }
 
 build_quiet_if_requested() {
-	if [[ "${SCRIPT_BUILD_QUIET}" == "true" ]]; then
+	if [[ "${BONITA_BUILD_QUIET}" == "true" ]]; then
 		echo "Configure quiet build"
 		build_command="$build_command --quiet"
 	fi
@@ -132,7 +132,7 @@ publishToMavenLocal() {
 }
 
 clean() {
-	if [[ "${SCRIPT_BUILD_NO_CLEAN}" == "true" ]]; then
+	if [[ "${BONITA_BUILD_NO_CLEAN}" == "true" ]]; then
 		echo "Configure build to skip clean task"
 	else
 		build_command="$build_command clean"

--- a/build-script.sh
+++ b/build-script.sh
@@ -228,11 +228,13 @@ logBuildSettings() {
 }
 
 checkPrerequisites() {
-    # Test that x server is running. Required to generate Bonita Studio models
-    # Can be ignored if Studio is build without the "generate" Maven profile
-    if ! xset q &>/dev/null; then
-        echo "No X server at \$DISPLAY [$DISPLAY]" >&2
-        exit 1
+	if [[ "${BONITA_BUILD_STUDIO_SKIP}" == "false" ]]; then
+        # Test that x server is running. Required to generate Bonita Studio models
+        # Can be ignored if Studio is build without the "generate" Maven profile
+        if ! xset q &>/dev/null; then
+            echo "No X server at \$DISPLAY [$DISPLAY]" >&2
+            exit 1
+        fi
     fi
 
     # Test that Maven exists

--- a/build-script.sh
+++ b/build-script.sh
@@ -219,6 +219,14 @@ build_gradle_wrapper_test_skip_publishToMavenLocal() {
 # PARAMETERS PARSING AND VALIDATIONS
 ########################################################################################################################
 
+logBuildSettings() {
+    echo "Build settings"
+    echo "  > BONITA_BUILD_NO_CLEAN: ${BONITA_BUILD_NO_CLEAN}"
+    echo "  > BONITA_BUILD_QUIET: ${BONITA_BUILD_QUIET}"
+    echo "  > BONITA_BUILD_STUDIO_ONLY: ${BONITA_BUILD_STUDIO_ONLY}"
+    echo "  > BONITA_BUILD_STUDIO_SKIP: ${BONITA_BUILD_STUDIO_SKIP}"
+}
+
 checkPrerequisites() {
     # Test that x server is running. Required to generate Bonita Studio models
     # Can be ignored if Studio is build without the "generate" Maven profile
@@ -357,6 +365,7 @@ detectWebPagesDependenciesVersions() {
 ########################################################################################################################
 # MAIN
 ########################################################################################################################
+logBuildSettings
 checkPrerequisites
 
 # List of repositories on https://github.com/bonitasoft that you don't need to build

--- a/build-script.sh
+++ b/build-script.sh
@@ -20,6 +20,8 @@ export OPENSSL_CONF=/etc/ssl
 # You can set the following environment variables
 SCRIPT_BUILD_NO_CLEAN=${SCRIPT_BUILD_NO_CLEAN:-false}
 SCRIPT_BUILD_QUIET=${SCRIPT_BUILD_QUIET:-false}
+BONITA_BUILD_STUDIO_ONLY=${BONITA_BUILD_STUDIO_ONLY:-false}
+BONITA_BUILD_STUDIO_SKIP=${BONITA_BUILD_STUDIO_SKIP:-false}
 
 # Bonita version
 BONITA_BPM_VERSION=7.9.4
@@ -388,42 +390,51 @@ checkPrerequisites
 # training-presentation-tool: fork of reveal.js with custom look and feel.
 # widget-builder: automatically downloaded in the build of bonita-ui-designer project.
 
-build_gradle_wrapper_test_skip_publishToMavenLocal bonita-engine
 
-build_maven_wrapper_install_skiptest bonita-userfilters
+if [[ "${BONITA_BUILD_STUDIO_ONLY}" == "false" ]]; then
+    build_gradle_wrapper_test_skip_publishToMavenLocal bonita-engine
 
-build_maven_wrapper_install_skiptest bonita-web-extensions
+    build_maven_wrapper_install_skiptest bonita-userfilters
 
-build_maven_wrapper_install_skiptest bonita-web
-# TODO with Bonita 7.10, we should be able to use the maven wrapper
-build_maven_install_skiptest bonita-portal-js
+    build_maven_wrapper_install_skiptest bonita-web-extensions
 
-# bonita-web-pages is build using a specific version of UI Designer.
-detectWebPagesDependenciesVersions
-build_maven_wrapper_install_skiptest bonita-ui-designer ${WEB_PAGES_UID_VERSION}
-build_gradle_wrapper_test_skip_publishToMavenLocal bonita-web-pages
+    build_maven_wrapper_install_skiptest bonita-web
+    # TODO with Bonita 7.10, we should be able to use the maven wrapper
+    build_maven_install_skiptest bonita-portal-js
 
-build_maven_wrapper_install_skiptest bonita-distrib
+    # bonita-web-pages is build using a specific version of UI Designer.
+    detectWebPagesDependenciesVersions
+    build_maven_wrapper_install_skiptest bonita-ui-designer ${WEB_PAGES_UID_VERSION}
+    build_gradle_wrapper_test_skip_publishToMavenLocal bonita-web-pages
 
-# Connectors
-detectConnectorsVersions
+    build_maven_wrapper_install_skiptest bonita-distrib
 
-build_maven_wrapper_install_skiptest bonita-connector-cmis ${CONNECTOR_VERSION_CMIS}
-build_maven_wrapper_install_skiptest bonita-connector-database ${CONNECTOR_VERSION_DATABASE}
-build_maven_wrapper_install_skiptest bonita-connector-email ${CONNECTOR_VERSION_EMAIL}
-build_maven_wrapper_install_skiptest bonita-connector-rest ${CONNECTOR_VERSION_REST}
-build_maven_wrapper_install_skiptest bonita-connector-salesforce ${CONNECTOR_VERSION_SALESFORCE}
-build_maven_wrapper_install_skiptest bonita-connector-scripting ${CONNECTOR_VERSION_SCRIPTING}
-build_maven_wrapper_install_skiptest bonita-connector-twitter ${CONNECTOR_VERSION_TWITTER}
-build_maven_wrapper_install_skiptest bonita-connector-webservice ${CONNECTOR_VERSION_WEBSERVICE}
-# connectors using legacy way of building
-build_maven_install_skiptest bonita-connector-alfresco ${CONNECTOR_VERSION_ALFRESCO}
-build_maven_install_skiptest bonita-connector-googlecalendar-V3 bonita-connector-google-calendar-v3-${CONNECTOR_VERSION_GOOGLE_CALENDAR_V3}
-build_maven_install_skiptest bonita-connector-ldap bonita-connector-ldap-${CONNECTOR_VERSION_LDAP}
+    # Connectors
+    detectConnectorsVersions
 
-detectStudioDependenciesVersions
-build_maven_install_skiptest bonita-studio-watchdog studio-watchdog-${STUDIO_WATCHDOG_VERSION}
-build_maven_wrapper_install_skiptest image-overlay-plugin image-overlay-plugin-${STUDIO_IMAGE_OVERLAY_PLUGIN_VERSION}
-build_maven_wrapper_install_skiptest bonita-ui-designer ${STUDIO_UID_VERSION}
+    build_maven_wrapper_install_skiptest bonita-connector-cmis ${CONNECTOR_VERSION_CMIS}
+    build_maven_wrapper_install_skiptest bonita-connector-database ${CONNECTOR_VERSION_DATABASE}
+    build_maven_wrapper_install_skiptest bonita-connector-email ${CONNECTOR_VERSION_EMAIL}
+    build_maven_wrapper_install_skiptest bonita-connector-rest ${CONNECTOR_VERSION_REST}
+    build_maven_wrapper_install_skiptest bonita-connector-salesforce ${CONNECTOR_VERSION_SALESFORCE}
+    build_maven_wrapper_install_skiptest bonita-connector-scripting ${CONNECTOR_VERSION_SCRIPTING}
+    build_maven_wrapper_install_skiptest bonita-connector-twitter ${CONNECTOR_VERSION_TWITTER}
+    build_maven_wrapper_install_skiptest bonita-connector-webservice ${CONNECTOR_VERSION_WEBSERVICE}
+    # connectors using legacy way of building
+    build_maven_install_skiptest bonita-connector-alfresco ${CONNECTOR_VERSION_ALFRESCO}
+    build_maven_install_skiptest bonita-connector-googlecalendar-V3 bonita-connector-google-calendar-v3-${CONNECTOR_VERSION_GOOGLE_CALENDAR_V3}
+    build_maven_install_skiptest bonita-connector-ldap bonita-connector-ldap-${CONNECTOR_VERSION_LDAP}
 
-build_maven_wrapper_verify_skiptest_with_profile bonita-studio mirrored,generate
+    detectStudioDependenciesVersions
+    build_maven_install_skiptest bonita-studio-watchdog studio-watchdog-${STUDIO_WATCHDOG_VERSION}
+    build_maven_wrapper_install_skiptest image-overlay-plugin image-overlay-plugin-${STUDIO_IMAGE_OVERLAY_PLUGIN_VERSION}
+    build_maven_wrapper_install_skiptest bonita-ui-designer ${STUDIO_UID_VERSION}
+else
+    echo "Skipping all build prior the Studio part"
+fi
+
+if [[ "${BONITA_BUILD_STUDIO_SKIP}" == "false" ]]; then
+    build_maven_wrapper_verify_skiptest_with_profile bonita-studio mirrored,generate
+else
+    echo "Skipping the Studio build"
+fi


### PR DESCRIPTION
We rely on `travis_wait` function to avoid build failure (as the Studio part does not write logs during 10 min) but currently
- the build fails after 50 minutes with empty cache
- we need to know which part of the build we are building on time limits failure to decide how to split the build in several jobs